### PR TITLE
Add description field to checklist

### DIFF
--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -3,7 +3,6 @@ _[Replace this line with a brief description of the work done or expected outcom
  Also please ensure any applicable jiras are in the title of the PR]_
 
 #### Compliance Checklist
-
 - [ ] I have verified that this is not a new project. If it is a new project (new service, new application, new repository), I have contacted the InfoSec team and completed their processes to gain proper approval from the following InfoSec team members:
 
 - [ ] I have verified that the backout plan for this change conforms to our standard engineering backout plan located [here](https://payitdev.atlassian.net/wiki/spaces/SEC/pages/2833416205/Standard+Change+Control+Back+Out+Plan). If it does not, I have documented an alternative backout plan below:

--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -2,6 +2,8 @@
 _[Replace this line with a brief description of the work done or expected outcome
  Also please ensure any applicable jiras are in the title of the PR]_
 
+#### Compliance Checklist
+
 - [ ] I have verified that this is not a new project. If it is a new project (new service, new application, new repository), I have contacted the InfoSec team and completed their processes to gain proper approval from the following InfoSec team members:
 
 - [ ] I have verified that the backout plan for this change conforms to our standard engineering backout plan located [here](https://payitdev.atlassian.net/wiki/spaces/SEC/pages/2833416205/Standard+Change+Control+Back+Out+Plan). If it does not, I have documented an alternative backout plan below:

--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -1,6 +1,6 @@
-####Description
-[Replace this line with a brief description of the work done or expected outcome
- Also please ensure any applicable jiras are in the title of the PR]
+#### Description
+_[Replace this line with a brief description of the work done or expected outcome
+ Also please ensure any applicable jiras are in the title of the PR]_
 
 - [ ] I have verified that this is not a new project. If it is a new project (new service, new application, new repository), I have contacted the InfoSec team and completed their processes to gain proper approval from the following InfoSec team members:
 

--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -1,4 +1,6 @@
-[Replace this line with a breif description of the work done or expected outcome]
+####Description
+[Replace this line with a brief description of the work done or expected outcome
+ Also please ensure any applicable jiras are in the title of the PR]
 
 - [ ] I have verified that this is not a new project. If it is a new project (new service, new application, new repository), I have contacted the InfoSec team and completed their processes to gain proper approval from the following InfoSec team members:
 

--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -1,3 +1,5 @@
+[Replace this line with a breif description of the work done or expected outcome]
+
 - [ ] I have verified that this is not a new project. If it is a new project (new service, new application, new repository), I have contacted the InfoSec team and completed their processes to gain proper approval from the following InfoSec team members:
 
 - [ ] I have verified that the backout plan for this change conforms to our standard engineering backout plan located [here](https://payitdev.atlassian.net/wiki/spaces/SEC/pages/2833416205/Standard+Change+Control+Back+Out+Plan). If it does not, I have documented an alternative backout plan below:


### PR DESCRIPTION
Hoping to add a section to the top of the checklist so people are prompted to provide at least a sentence about what they did or are hoping to accomplish.  This should also hopefully prevent every autopopulated slack preview from just being the checklist.

- [x] I have verified that this is not a new project. If it is a new project (new service, new application, new repository), I have contacted the InfoSec team and completed their processes to gain proper approval from the following InfoSec team members:

- [x] I have verified that the backout plan for this change conforms to our standard engineering backout plan located [here](https://payitdev.atlassian.net/wiki/spaces/SEC/pages/2833416205/Standard+Change+Control+Back+Out+Plan). If it does not, I have documented an alternative backout plan below:

- [x] I have verified that this change is backwards compatible. If it is not, I have specified the breaking changes and how they will be handled below:

- [x] I have verified that this change will not impact the security controls built into the application or introduce any new security vulnerabilities. If it will, I have defined the security impact below:

- [x] I have verified that this change will not result in downtime. If it will, I have noted the impact below:

- [x] I have verified that no new dependencies were introduced. If they were, I have vetted them below:

- [x] I have verified that all applicable tests were updated to ensure complete test coverage of any new or modified code.

- [x] I have verified that any relevant documentation such as the README is still up to date and not impacted by my changes. If documentation needs updating for accuracy, I have done so. 
