### PR TITLE
Make PR compliance checklist collapsible

### DIFF
--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -7,7 +7,7 @@
         - Good pull request title: "[JIRA-123] add index on `customerId` field"
         - Bad pull request title: "fix query" -->
 
-<details>
+<details open>
 <summary><h4>Compliance Checklist</h4></summary>
 
 - [ ] I have verified that this is not a new project. If it is a new project (new service, new application, new repository), I have contacted the InfoSec team and completed their processes to gain proper approval from the following InfoSec team members:

--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -1,8 +1,15 @@
-#### Description
-_[Replace this line with a brief description of the work done or expected outcome
- Also please ensure any applicable jiras are in the title of the PR]_
+<h4>Description</h4>
 
-<details><summary><h4>Compliance Checklist</h4></summary>
+<!-- Add a description of the changes introduced in this pull request. -->
+
+<!-- Please give the pull request a meaningful title, and please ensure any applicable
+     Jira issues's keys are included in the title of the pull request.
+        - Good pull request title: "[JIRA-123] add index on `customerId` field"
+        - Bad pull request title: "fix query" -->
+
+<details>
+<summary><h4>Compliance Checklist</h4></summary>
+
 - [ ] I have verified that this is not a new project. If it is a new project (new service, new application, new repository), I have contacted the InfoSec team and completed their processes to gain proper approval from the following InfoSec team members:
 
 - [ ] I have verified that the backout plan for this change conforms to our standard engineering backout plan located [here](https://payitdev.atlassian.net/wiki/spaces/SEC/pages/2833416205/Standard+Change+Control+Back+Out+Plan). If it does not, I have documented an alternative backout plan below:

--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -2,7 +2,7 @@
 _[Replace this line with a brief description of the work done or expected outcome
  Also please ensure any applicable jiras are in the title of the PR]_
 
-#### Compliance Checklist
+<details><summary><h4>Compliance Checklist</h4></summary>
 - [ ] I have verified that this is not a new project. If it is a new project (new service, new application, new repository), I have contacted the InfoSec team and completed their processes to gain proper approval from the following InfoSec team members:
 
 - [ ] I have verified that the backout plan for this change conforms to our standard engineering backout plan located [here](https://payitdev.atlassian.net/wiki/spaces/SEC/pages/2833416205/Standard+Change+Control+Back+Out+Plan). If it does not, I have documented an alternative backout plan below:
@@ -17,4 +17,5 @@ _[Replace this line with a brief description of the work done or expected outcom
 
 - [ ] I have verified that all applicable tests were updated to ensure complete test coverage of any new or modified code.
 
-- [ ] I have verified that any relevant documentation such as the README is still up to date and not impacted by my changes. If documentation needs updating for accuracy, I have done so. 
+- [ ] I have verified that any relevant documentation such as the README is still up to date and not impacted by my changes. If documentation needs updating for accuracy, I have done so.
+</details>


### PR DESCRIPTION
#### Description

Changes:
* Make PR template compliance checklist collapsible.
* Move the "description" field's placeholder text into an HTML comment so that while you will still see it when editing the PR description, it won't need to be deleted in order to not show in the rendered PR. (Should save a second or two on every PR which will add up!)

#### Compliance Checklist

- [X] I have verified that this is not a new project. If it is a new project (new service, new application, new repository), I have contacted the InfoSec team and completed their processes to gain proper approval from the following InfoSec team members:

- [X] I have verified that the backout plan for this change conforms to our standard engineering backout plan located [here](https://payitdev.atlassian.net/wiki/spaces/SEC/pages/2833416205/Standard+Change+Control+Back+Out+Plan). If it does not, I have documented an alternative backout plan below:

- [X] I have verified that this change is backwards compatible. If it is not, I have specified the breaking changes and how they will be handled below:

- [X] I have verified that this change will not impact the security controls built into the application or introduce any new security vulnerabilities. If it will, I have defined the security impact below:

- [X] I have verified that this change will not result in downtime. If it will, I have noted the impact below:

- [X] I have verified that no new dependencies were introduced. If they were, I have vetted them below:

- [X] I have verified that all applicable tests were updated to ensure complete test coverage of any new or modified code.

- [X] I have verified that any relevant documentation such as the README is still up to date and not impacted by my changes. If documentation needs updating for accuracy, I have done so. 
