### PR TITLE
ci: expose just the compliance stuff

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,0 +1,21 @@
+<!-- payit-compliance-checklist-start -->
+<details open>
+<summary><h4>Compliance Checklist</h4></summary>
+
+- [ ] I have verified that this is not a new project. If it is a new project (new service, new application, new repository), I have [submitted a ticket to InfoSec](https://payitdev.atlassian.net/servicedesk/customer/portal/15/group/154/create/526) to review the new project and gained approval.
+
+- [ ] I have verified that the backout plan for this change conforms to our standard engineering backout plan located [here](https://payitdev.atlassian.net/wiki/spaces/SEC/pages/2833416205/Standard+Change+Control+Back+Out+Plan). If it does not, I have documented an alternative backout plan below:
+
+- [ ] I have verified that this change is backwards compatible. If it is not, I have specified the breaking changes and how they will be handled below:
+
+- [ ] I have verified that this change will not impact the security controls built into the application or introduce any new security vulnerabilities. If it will, I have defined the security impact below:
+
+- [ ] I have verified that this change will not result in downtime. If it will, I have noted the impact below:
+
+- [ ] I have verified that no new dependencies were introduced. If they were, I have vetted them below:
+
+- [ ] I have verified that all applicable tests were updated to ensure complete test coverage of any new or modified code.
+
+- [ ] I have verified that any relevant documentation such as the README is still up to date and not impacted by my changes. If documentation needs updating for accuracy, I have done so.
+</details>
+<!-- payit-compliance-checklist-end -->


### PR DESCRIPTION
<h4>Description</h4>

expose the compliance stuff as a file to 

<!-- payit-compliance-checklist-start -->
<details open>
<summary><h4>Compliance Checklist</h4></summary>

- [x] I have verified that this is not a new project. If it is a new project (new service, new application, new repository), I have [submitted a ticket to InfoSec](https://payitdev.atlassian.net/servicedesk/customer/portal/15/group/154/create/526) to review the new project and gained approval.

- [x] I have verified that the backout plan for this change conforms to our standard engineering backout plan located [here](https://payitdev.atlassian.net/wiki/spaces/SEC/pages/2833416205/Standard+Change+Control+Back+Out+Plan). If it does not, I have documented an alternative backout plan below:

- [x] I have verified that this change is backwards compatible. If it is not, I have specified the breaking changes and how they will be handled below:

- [x] I have verified that this change will not impact the security controls built into the application or introduce any new security vulnerabilities. If it will, I have defined the security impact below:

- [x] I have verified that this change will not result in downtime. If it will, I have noted the impact below:

- [x] I have verified that no new dependencies were introduced. If they were, I have vetted them below:

- [x] I have verified that all applicable tests were updated to ensure complete test coverage of any new or modified code.

- [x] I have verified that any relevant documentation such as the README is still up to date and not impacted by my changes. If documentation needs updating for accuracy, I have done so.
</details>
<!-- payit-compliance-checklist-end -->	